### PR TITLE
Joinnotifier feature: Notifications for friends regardless of instance type

### DIFF
--- a/JoinNotifier/JoinNotifierMod.cs
+++ b/JoinNotifier/JoinNotifierMod.cs
@@ -246,9 +246,12 @@ namespace JoinNotifier
             }
 
             if (!myObservedLocalPlayerJoin || Environment.TickCount - myLastLevelLoad < 5_000) return;
-            if (!JoinNotifierSettings.ShouldNotifyInCurrentInstance()) return;
             var isFriendsWith = APIUser.IsFriendsWith(apiUser.id);
-            if (JoinNotifierSettings.ShowFriendsOnly() && !isFriendsWith) return;
+            if (!isFriendsWith || !JoinNotifierSettings.ShowFriendsAlways())
+            {
+                if (!JoinNotifierSettings.ShouldNotifyInCurrentInstance()) return;
+                if (JoinNotifierSettings.ShowFriendsOnly() && !isFriendsWith) return;
+            }
             var playerName = apiUser.displayName ?? "!null!";
             if (JoinNotifierSettings.ShouldBlinkIcon(true))
                 MelonCoroutines.Start(BlinkIconCoroutine(myJoinImage));
@@ -262,10 +265,15 @@ namespace JoinNotifier
         {
             var apiUser = player?.field_Private_APIUser_0;
             if (apiUser == null) return;
-            if (!JoinNotifierSettings.ShouldNotifyInCurrentInstance()) return;
             if (Environment.TickCount - myLastLevelLoad < 5_000) return;
+
             var isFriendsWith = APIUser.IsFriendsWith(apiUser.id);
-            if (JoinNotifierSettings.ShowFriendsOnly() && !isFriendsWith) return;
+            if (!isFriendsWith || !JoinNotifierSettings.ShowFriendsAlways())
+            {
+                if (!JoinNotifierSettings.ShouldNotifyInCurrentInstance()) return;
+                if (JoinNotifierSettings.ShowFriendsOnly() && !isFriendsWith) return;
+            }
+
             var playerName = apiUser.displayName ?? "!null!";
             if (JoinNotifierSettings.ShouldBlinkIcon(false))
                 MelonCoroutines.Start(BlinkIconCoroutine(myLeaveImage));

--- a/JoinNotifier/JoinNotifierSettings.cs
+++ b/JoinNotifier/JoinNotifierSettings.cs
@@ -22,6 +22,7 @@ namespace JoinNotifier
         private const string SettingLeaveIconColor = "LeaveColor";
         private const string SettingShowFriendsInDifferentColor = "ShowFriendsInDifferentColor";
         private const string SettingShowFriendsOnly = "ShowFriendsOnly";
+        private const string SettingShowFriendsAlways = "ShowFriendsAlways";
         private const string SettingFriendsJoinColor = "FriendJoinColor";
         private const string SettingFriendsLeaveColor = "FriendLeaveColor";
         
@@ -48,6 +49,7 @@ namespace JoinNotifier
             MelonPrefs.RegisterBool(SettingsCategory, SettingNotifyPrivate, true, "Notify in private instances");
 
             MelonPrefs.RegisterBool(SettingsCategory, SettingShowFriendsOnly, false, "Show friend join/leave only");
+            MelonPrefs.RegisterBool(SettingsCategory, SettingShowFriendsAlways, false, "Show friend join/leave regardless of instance type");
             MelonPrefs.RegisterString(SettingsCategory, SettingJoinIconColor, "127 191 255", "Join icon color (r g b)");
             MelonPrefs.RegisterString(SettingsCategory, SettingLeaveIconColor, "153 82 51", "Leave icon color (r g b)");
             
@@ -85,6 +87,7 @@ namespace JoinNotifier
             MelonPrefs.GetBool(SettingsCategory, isJoin ? SettingJoinShowName : SettingLeaveShowName);
 
         public static bool ShowFriendsOnly() => MelonPrefs.GetBool(SettingsCategory, SettingShowFriendsOnly);
+        public static bool ShowFriendsAlways() => MelonPrefs.GetBool(SettingsCategory, SettingShowFriendsAlways);
         public static bool ShowFriendsInDifferentColor() => MelonPrefs.GetBool(SettingsCategory, SettingShowFriendsInDifferentColor);
 
         public static float GetSoundVolume() => MelonPrefs.GetFloat(SettingsCategory, SettingSoundVolume);


### PR DESCRIPTION
My ideal joining notifications configuration would allow me to get notified for friends joining/leaving always, and be able to tweak the notifications for other people. Just adding an option to skip for the instance type checks for friends seems like the simplest way to achieve that.

Thought that other people might find that useful too, and I am not too excited in maintaining a fork for a project in a language that am not too deeply familiar with, thusly the PR :)