### PR TITLE
LFS: Context metadata in photos; Autorotation

### DIFF
--- a/LagFreeScreenshots/LagFreeScreenshotsMod.cs
+++ b/LagFreeScreenshots/LagFreeScreenshotsMod.cs
@@ -19,6 +19,7 @@ using UnhollowerRuntimeLib.XrefScans;
 using UnityEngine;
 using UnityEngine.Rendering;
 using VRC.UserCamera;
+using VRC.Core;
 using VRC;
 using Object = UnityEngine.Object;
 using CameraTakePhotoEnumerator = VRC.UserCamera.CameraUtil.ObjectNPrivateSealedIEnumerator1ObjectIEnumeratorIDisposableInObBoAcIn2StInTeCaUnique;
@@ -103,12 +104,12 @@ namespace LagFreeScreenshots
             return String.Join(";", result);
         }
 
-        private static string GetWorldName()
+        private static string GetPhotographerMeta()
         {
-            return RoomManager.field_Internal_Static_ApiWorld_0.name;
+            return APIUser.CurrentUser.id + "," + APIUser.CurrentUser.displayName;
         }
 
-        private static string GetWorldInstanceId()
+        private static string GetWorldMeta()
         {
             return RoomManager.field_Internal_Static_ApiWorld_0.id + "," + RoomManager.field_Internal_Static_ApiWorldInstance_0.idOnly;
         }
@@ -219,7 +220,7 @@ namespace LagFreeScreenshots
             string metadataStr = null;
 
             if (ourMetadata.Value) { 
-                metadataStr = "lfs|1|world:" + GetWorldInstanceId() + "," + GetWorldName() + "|players:" + GetPlayerList(camera);
+                metadataStr = "lfs|1|author:" + GetPhotographerMeta() + "|world:" + GetWorldMeta() + "|players:" + GetPlayerList(camera);
             }
 
             await EncodeAndSavePicture(targetFile, data, w, h, hasAlpha, metadataStr).ConfigureAwait(false);

--- a/LagFreeScreenshots/LagFreeScreenshotsMod.cs
+++ b/LagFreeScreenshots/LagFreeScreenshotsMod.cs
@@ -111,7 +111,7 @@ namespace LagFreeScreenshots
 
         private static string GetWorldMeta()
         {
-            return RoomManager.field_Internal_Static_ApiWorld_0.id + "," + RoomManager.field_Internal_Static_ApiWorldInstance_0.idOnly;
+            return RoomManager.field_Internal_Static_ApiWorld_0.id + "," + RoomManager.field_Internal_Static_ApiWorldInstance_0.idOnly + "," + RoomManager.field_Internal_Static_ApiWorld_0.name;
         }
 
         public override void OnUpdate()

--- a/LagFreeScreenshots/LagFreeScreenshotsMod.cs
+++ b/LagFreeScreenshots/LagFreeScreenshotsMod.cs
@@ -81,23 +81,21 @@ namespace LagFreeScreenshots
 
             var localPlayer = VRCPlayer.field_Internal_Static_VRCPlayer_0;
             var localPosition = localPlayer.gameObject.transform.position;
-            var localAngle = localPlayer.gameObject.transform.rotation;
 
             foreach (var p in playerManager.field_Private_List_1_Player_0)
             {
-                var playerDescriptor = p.prop_APIUser_0.id + "," + p.prop_APIUser_0.displayName;
                 var playerPosition = p.gameObject.transform.position;
-                if (Vector3.Distance(localPosition, playerPosition) < 3) {
+                Vector3 viewPos = camera.WorldToViewportPoint(playerPosition);
+                var playerDescriptor = p.prop_APIUser_0.id + "," + viewPos.x.ToString("0.00") + "," + viewPos.y.ToString("0.00") + "," + viewPos.z.ToString("0.00") + "," + p.prop_APIUser_0.displayName;
+                
+                if (viewPos.z < 2 && Vector3.Distance(localPosition, playerPosition) < 2) {
                     //User standing right next to photographer, might be visible (approx.)
                     result.Add(playerDescriptor);
                 }
-                else
+                else if (viewPos.x > -0.03 && viewPos.x < 1.03 && viewPos.y > -0.03 && viewPos.y < 1.03 && viewPos.z > 2 && viewPos.z < 30)
                 {
-                    Vector3 viewPos = camera.WorldToViewportPoint(playerPosition);
-                    if (viewPos.x >= 0 && viewPos.x <= 1 && viewPos.y >= 0 && viewPos.y <= 1 && viewPos.z > 2 && viewPos.z < 50) {
-                        //User in viewport, might be obstructed but still...
-                        result.Add(playerDescriptor);
-                    }
+                    //User in viewport, might be obstructed but still...
+                    result.Add(playerDescriptor);
                 }
             }
 
@@ -157,7 +155,7 @@ namespace LagFreeScreenshots
 
             var oldCameraTarget = camera.targetTexture;
             var oldCameraFov = camera.fieldOfView;
-            
+
             camera.targetTexture = renderTexture;
             
             camera.Render();
@@ -220,7 +218,7 @@ namespace LagFreeScreenshots
             string metadataStr = null;
 
             if (ourMetadata.Value) { 
-                metadataStr = "lfs|1|author:" + GetPhotographerMeta() + "|world:" + GetWorldMeta() + "|players:" + GetPlayerList(camera);
+                metadataStr = "lfs|2|author:" + GetPhotographerMeta() + "|world:" + GetWorldMeta() + "|players:" + GetPlayerList(camera);
             }
 
             await EncodeAndSavePicture(targetFile, data, w, h, hasAlpha, metadataStr).ConfigureAwait(false);
@@ -305,7 +303,7 @@ namespace LagFreeScreenshots
                 var pi = (PropertyItem)FormatterServices.GetUninitializedObject(typeof(PropertyItem));
                 pi.Type = 2;
                 pi.Id = 0x010E;  //PropertyTagImageDescription
-                pi.Value = Encoding.UTF8.GetBytes(description);
+                pi.Value = Encoding.Convert(Encoding.Unicode, Encoding.UTF8, Encoding.Unicode.GetBytes(description));
                 pi.Len = pi.Value.Length;
                 bitmap.SetPropertyItem(pi);
             }


### PR DESCRIPTION
Might you be persuaded to add this feature to LFS? I tested it and it seems to be working as intended.

The aim is to include in the photos taken in VRChat the (VRChat) identity of the author, the world, and a list of players who may have been visible in the photo. GDI+ stores this line of data in EXIF for JPEGs (readable in the windows explorer properties) and in a tEXt chunk for PNGs. Other software can then use this information to annotate the photo without users having to remember who the people in the photo were, since most VRChat users change avatars all the time and take a prodigious amount of photos.

The JPEG metadata unfortunately does not survive upload to Discord, but it appears that the PNG metadata does. I intend to make my community's Discord bot automatically extract it and display the list of users and links to the relevant vrchat.com pages.

It's my first "mod," so do tell me if I made any mistake, and feel free to change the way it works. If you'd like to discuss the feature I'm on Discord as Protected#4053 .