### PR TITLE
UIX: Fix visible CameraExpando in Camera rendering

### DIFF
--- a/UIExpansionKit/CustomCameraPageImpl.cs
+++ b/UIExpansionKit/CustomCameraPageImpl.cs
@@ -25,7 +25,7 @@ namespace UIExpansionKit
             transform.localScale = Vector3.one;
             transform.Cast<RectTransform>().localPosition = new Vector3(0, 0, -0.003f + -0.001f * layer);
             
-            UiExpansionKitMod.SetLayerRecursively(transform.gameObject, 4);
+            UiExpansionKitMod.SetLayerRecursively(transform.gameObject, LayerMask.NameToLayer("UI"));
         }
     }
 }


### PR DESCRIPTION
The CameraExpando was visible in the Camera. The Content object had the layer "Water" which is not correct, I put UI here. Also I used the LayerMask so it's future proof. In fact it's totally possible this bug is the result of VRC changing layer id.

Not sure if "UI" is the one we want here but it works in game.