### PR TITLE
UIX: CategoriesStartCollapsed should default to true

### DIFF
--- a/UIExpansionKit/ExpansionKitSettings.cs
+++ b/UIExpansionKit/ExpansionKitSettings.cs
@@ -23,7 +23,7 @@ namespace UIExpansionKit
             PinsEntry = category.CreateEntry(PinnedPrefs, "", is_hidden: true);
             
             category.CreateEntry(QmExpandoStartsCollapsed, false, "Quick Menu extra panel starts hidden");
-            category.CreateEntry(CategoriesStartCollapsed, false, "Settings categories start collapsed");
+            category.CreateEntry(CategoriesStartCollapsed, true, "Settings categories start collapsed");
             category.CreateEntry(CameraExpandoStartsCollapsed, true, "Camera expanded menu starts collapsed");
             
             category.CreateEntry(QmExpandoMinRows, 1, "Minimum rows in Quick Menu extra panel");


### PR DESCRIPTION
Quality of life change

There's no real reason this should be defaulting false at all, having them collapsed at first launch is a better first user experience IMO.