### PR TITLE
LFS: Faster autorotate and bytes operations + LfsApi: Add ScreenshotTextureEvent

### DIFF
--- a/LagFreeScreenshots/API/LfsApi.cs
+++ b/LagFreeScreenshots/API/LfsApi.cs
@@ -5,7 +5,7 @@ namespace LagFreeScreenshots.API
     public static class LfsApi
     {
         /// <summary>
-        /// Called after a creenshot is taken and written to disk
+        /// Called after a screenshot is taken and written to disk
         /// </summary>
         public static event ScreenshotSavedEventV2? OnScreenshotSavedV2;
 
@@ -13,5 +13,15 @@ namespace LagFreeScreenshots.API
 
         internal static void InvokeScreenshotSaved(string filePath, int width, int height, MetadataV2? metadataV2) =>
             OnScreenshotSavedV2?.Invoke(filePath, width, height, metadataV2);
+
+
+        /// <summary>
+        /// Called just after the camera rendered to this RenderTexture (just before it will be destroyed)
+        /// It's right time to make a GPU copy with Graphics.CopyTexture for example
+        /// </summary>
+        public static event ScreenshotTextureEvent? OnScreenshotTexture;
+        public delegate void ScreenshotTextureEvent(UnityEngine.RenderTexture texture);
+        internal static void InvokeScreenshotTexture(UnityEngine.RenderTexture texture) =>
+            OnScreenshotTexture?.Invoke(texture);
     }
 }

--- a/LagFreeScreenshots/LagFreeScreenshotsMod.cs
+++ b/LagFreeScreenshots/LagFreeScreenshotsMod.cs
@@ -270,6 +270,7 @@ namespace LagFreeScreenshots
             QualitySettings.antiAliasing = oldGraphicsMsaa;
             
             renderTexture.ResolveAntiAliasedSurface();
+            LfsApi.InvokeScreenshotTexture(renderTexture);
 
             (IntPtr, int) data = default;
             var readbackSupported = SystemInfo.supportsAsyncGPUReadback;


### PR DESCRIPTION
This PR optimize the bytes and autorotation of screenshot after rendering. Some real numbers:

```
with 4K rendering

daky optimized v2 (this PR)
rgb 22ms!
rgba 20ms!

knah:
0°
rgb 55-65ms
rgba 80ms

270° 
rgb 260ms
rgba 280ms

90°
rgb 100ms
rgba 130ms

180°
rgb 100ms
rgba 145ms
```

Details: Unity render is horizontally swapped so we need to mirror swap on X:
That part was rewritten so it's simplified and optimized. Old code was doing the byte wizardry and then using another marshall.Copy which were combined in this PR and thus saving operations and memory.

Also if autorotate previous code was doing byte wizardry but that's not
necessary and slow. In this new version we manipulate the camera so it's always
upright before the rendering. So then there is no need to fix and correct anything except for the above mentioned unity X swap. Enjoy.

Also I added a new event (2nd commit) that allows more modding possibilities: For ex I have a WIP mod that allows to spawn the camera photos in VR directly. 