### PR TITLE
Convert (nearly) all usages of MelonLogger to MelonLogger.Instance

### DIFF
--- a/AdvancedSafety/AdvancedSafetyMod.cs
+++ b/AdvancedSafety/AdvancedSafetyMod.cs
@@ -26,6 +26,8 @@ namespace AdvancedSafety
 {
     internal partial class AdvancedSafetyMod : MelonMod
     {
+        public static MelonLogger.Instance Logger;
+        
         internal static bool CanReadAudioMixers = true;
         internal static bool CanReadBadFloats = true;
 
@@ -35,6 +37,8 @@ namespace AdvancedSafety
         public override void OnApplicationStart()
         {
             if (!CheckWasSuccessful || !MustStayTrue || MustStayFalse) return;
+
+            Logger = LoggerInstance;
             
             AdvancedSafetySettings.RegisterSettings();
             ClassInjector.RegisterTypeInIl2Cpp<SortingOrderHammerer>();
@@ -45,7 +49,7 @@ namespace AdvancedSafety
             }
             catch (Exception ex)
             {
-                MelonLogger.Error($"Error initializing Bundle Verifier: {ex}");
+                Logger.Error($"Error initializing Bundle Verifier: {ex}");
             }
 
             var matchingMethods = typeof(AssetManagement)
@@ -251,7 +255,7 @@ namespace AdvancedSafety
                 go.AddComponent<SortingOrderHammerer>();
 
             if (MelonDebug.IsEnabled() || destroyedObjects > 100)
-                MelonLogger.Msg($"Cleaned avatar ({avatarManager.field_Private_ApiAvatar_0?.name}) used by \"{vrcPlayer.prop_VRCPlayerApi_0?.displayName}\" in {start.ElapsedMilliseconds}ms, scanned {scannedObjects} things, destroyed {destroyedObjects} things");
+                Logger.Msg($"Cleaned avatar ({avatarManager.field_Private_ApiAvatar_0?.name}) used by \"{vrcPlayer.prop_VRCPlayerApi_0?.displayName}\" in {start.ElapsedMilliseconds}ms, scanned {scannedObjects} things, destroyed {destroyedObjects} things");
         }
 
         private static IEnumerator CheckSpawnSounds(GameObject go, List<AudioSource> audioSourcesList)
@@ -303,7 +307,7 @@ namespace AdvancedSafety
             }
             catch (Exception ex)
             {
-                MelonLogger.Error($"Exception when cleaning avatar: {ex}");
+                Logger.Error($"Exception when cleaning avatar: {ex}");
             }
             
             return result;

--- a/AdvancedSafety/AvatarHiding.cs
+++ b/AdvancedSafety/AvatarHiding.cs
@@ -101,7 +101,7 @@ namespace AdvancedSafety
                 if (ourBlockedAvatarAuthors.ContainsKey(apiAvatar.authorId) ||
                     ourBlockedAvatars.ContainsKey(apiAvatar.id))
                 {
-                    MelonLogger.Msg(
+                    AdvancedSafetyMod.Logger.Msg(
                         $"Hiding avatar on {apiUser.displayName} because it or its author is hidden");
                     // denyReason = 3;
                     __result = false;
@@ -109,7 +109,7 @@ namespace AdvancedSafety
             }
             catch (Exception ex)
             {
-                MelonLogger.Error($"Exception in CanUseCustomAvatarPatch: {ex}");
+                AdvancedSafetyMod.Logger.Error($"Exception in CanUseCustomAvatarPatch: {ex}");
             }
         }
 

--- a/AdvancedSafety/BundleVerifier/BundleDlContext.cs
+++ b/AdvancedSafety/BundleVerifier/BundleDlContext.cs
@@ -48,7 +48,7 @@ namespace AdvancedSafety.BundleVerifier
             }
             catch (Exception ex)
             {
-                MelonLogger.Error($"Error while initializing verifier internals: {ex}");
+                AdvancedSafetyMod.Logger.Error($"Error while initializing verifier internals: {ex}");
                 return false;
             }
 
@@ -63,8 +63,8 @@ namespace AdvancedSafety.BundleVerifier
             }
             catch (IOException ex)
             {
-                MelonLogger.Error($"Received more bytes than declared for bundle URL {Url} (declared: {BundleDlInterceptor.GetTotalSize(OriginalBundleDownload)})");
-                MelonLogger.Error(ex.ToString());
+                AdvancedSafetyMod.Logger.Error($"Received more bytes than declared for bundle URL {Url} (declared: {BundleDlInterceptor.GetTotalSize(OriginalBundleDownload)})");
+                AdvancedSafetyMod.Logger.Error(ex.ToString());
                 DoBackSpew();
                 unsafe
                 {
@@ -100,7 +100,7 @@ namespace AdvancedSafety.BundleVerifier
             if (exitCode != 0)
             {
                 var cleanedUrl = BundleVerifierMod.SanitizeUrl(Url);
-                MelonLogger.Msg($"Verifier process failed with exit code {exitCode} ({VerifierExitCodes.GetExitCodeDescription(exitCode)}) for bundle uid={cleanedUrl.Item1}+{cleanedUrl.Item2}");
+                AdvancedSafetyMod.Logger.Msg($"Verifier process failed with exit code {exitCode} ({VerifierExitCodes.GetExitCodeDescription(exitCode)}) for bundle uid={cleanedUrl.Item1}+{cleanedUrl.Item2}");
                 BundleVerifierMod.BadBundleCache.Add(Url);
                 MelonDebug.Msg("Reporting completion without data");
                 // feed some garbage into it, otherwise it dies

--- a/AdvancedSafety/BundleVerifier/BundleDlInterceptor.cs
+++ b/AdvancedSafety/BundleVerifier/BundleDlInterceptor.cs
@@ -37,7 +37,7 @@ namespace AdvancedSafety.BundleVerifier
             if (ourInterceptedContext.TryGetValue(thisPtr, out var context) && context.IsBadUrl)
             {
                 var cleanedUrl = BundleVerifierMod.SanitizeUrl(context.Url);
-                MelonLogger.Msg($"Bundle for ptr {thisPtr} uid={cleanedUrl.Item1}+{cleanedUrl.Item2} is pre-marked as bad, faking failed download");
+                AdvancedSafetyMod.Logger.Msg($"Bundle for ptr {thisPtr} uid={cleanedUrl.Item1}+{cleanedUrl.Item2} is pre-marked as bad, faking failed download");
                 // indicate that it should use the DL stream
                 Marshal.WriteInt32(thisPtr + 0x90, 1);
                 // and then indicate the downloader that we don't want the download

--- a/AdvancedSafety/BundleVerifier/BundleDownloadMethods.cs
+++ b/AdvancedSafety/BundleVerifier/BundleDownloadMethods.cs
@@ -43,8 +43,8 @@ namespace AdvancedSafety.BundleVerifier
 
             if (!ourBundleDownloadOffsets.TryGetValue(unityPlayerHash, out var offsets))
             {
-                MelonLogger.Error($"Unknown UnityPlayer hash: {unityPlayerHash}");
-                MelonLogger.Error("Bundle verifier will not work");
+                AdvancedSafetyMod.Logger.Error($"Unknown UnityPlayer hash: {unityPlayerHash}");
+                AdvancedSafetyMod.Logger.Error("Bundle verifier will not work");
                 return false;
             }
 
@@ -91,7 +91,7 @@ namespace AdvancedSafety.BundleVerifier
             }
             catch (Exception ex)
             {
-                MelonLogger.Error($"Exception in CreateCached patch: {ex}");
+                AdvancedSafetyMod.Logger.Error($"Exception in CreateCached patch: {ex}");
             }
             return result;
         }

--- a/AdvancedSafety/BundleVerifier/BundleHashCache.cs
+++ b/AdvancedSafety/BundleVerifier/BundleHashCache.cs
@@ -29,7 +29,7 @@ namespace AdvancedSafety.BundleVerifier
                 var readBytes = myHashWriterStream.Read(transferArray, 0, transferArray.Length);
                 if (readBytes != transferArray.Length)
                 {
-                    MelonLogger.Error($"Failure to read {transferArray.Length} bytes from cached bad URL file");
+                    AdvancedSafetyMod.Logger.Error($"Failure to read {transferArray.Length} bytes from cached bad URL file");
                     myHashWriterStream.Position = 0;
                     break;
                 }

--- a/AdvancedSafety/BundleVerifier/BundleVerifierMod.cs
+++ b/AdvancedSafety/BundleVerifier/BundleVerifierMod.cs
@@ -47,8 +47,8 @@ namespace AdvancedSafety.BundleVerifier
             }
             catch (IOException ex)
             {
-                MelonLogger.Error("Unable to extract bundle verifier app, the mod will not work");
-                MelonLogger.Error(ex.ToString());
+                AdvancedSafetyMod.Logger.Error("Unable to extract bundle verifier app, the mod will not work");
+                AdvancedSafetyMod.Logger.Error(ex.ToString());
                 return;
             }
 
@@ -84,7 +84,7 @@ namespace AdvancedSafety.BundleVerifier
             if (!EnabledSetting.Value)
             {
                 BundleDlInterceptor.ShouldIntercept = false;
-                MelonLogger.Msg($"Bundle intercept disabled in settings");
+                AdvancedSafetyMod.Logger.Msg($"Bundle intercept disabled in settings");
                 yield break;
             }
 

--- a/AdvancedSafety/PortalHiding.cs
+++ b/AdvancedSafety/PortalHiding.cs
@@ -45,7 +45,7 @@ namespace AdvancedSafety
                 if (APIUser.CurrentUser?.id == apiUser.id) return;
                 
                 if (MelonDebug.IsEnabled())
-                    MelonLogger.Msg($"User {apiUser.displayName} dropped a portal");
+                    AdvancedSafetyMod.Logger.Msg($"User {apiUser.displayName} dropped a portal");
 
                 string denyReason = null;
                 if (AdvancedSafetySettings.HidePortalsFromBlockedUsers.Value && IsBlockedEitherWay(apiUser.id))
@@ -62,13 +62,13 @@ namespace AdvancedSafety
                 if (dict.ContainsKey(networkId))
                 {
                     var someStruct = dict[networkId];
-                    MelonLogger.Msg(denyReason);
+                    AdvancedSafetyMod.Logger.Msg(denyReason);
                     MelonCoroutines.Start(HideGameObjectAfterDelay(someStruct.field_Public_GameObject_0));
                 }
             }
             catch (Exception ex)
             {
-                MelonLogger.Error($"Exception in portal hider patch: {ex}");
+                AdvancedSafetyMod.Logger.Error($"Exception in portal hider patch: {ex}");
             }
         }
 

--- a/AdvancedSafety/ReaderPatches.cs
+++ b/AdvancedSafety/ReaderPatches.cs
@@ -48,8 +48,8 @@ namespace AdvancedSafety
 
             if (!ourOffsets.TryGetValue(unityPlayerHash, out var offsets))
             {
-                MelonLogger.Error($"Unknown UnityPlayer hash: {unityPlayerHash}");
-                MelonLogger.Error("Some features will not work");
+                AdvancedSafetyMod.Logger.Error($"Unknown UnityPlayer hash: {unityPlayerHash}");
+                AdvancedSafetyMod.Logger.Error("Some features will not work");
                 return;
             }
 
@@ -238,7 +238,7 @@ namespace AdvancedSafety
             }
             catch (Exception ex)
             {
-                MelonLogger.Error($"Exception in CountNodes patch: {ex}");
+                AdvancedSafetyMod.Logger.Error($"Exception in CountNodes patch: {ex}");
                 return 1;
             }
         }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -90,6 +90,11 @@
             <Private>false</Private>
             <HintPath>$(MsBuildThisFileDirectory)Libs\MelonLoader.dll</HintPath>
         </Reference>
+		<Reference Include="0Harmony">
+            <SpecificVersion>false</SpecificVersion>
+            <Private>false</Private>
+            <HintPath>$(MsBuildThisFileDirectory)Libs\0Harmony.dll</HintPath>
+        </Reference>
         <Reference Include="UnhollowerBaseLib, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
             <SpecificVersion>false</SpecificVersion>
             <Private>false</Private>

--- a/FavCat/CustomLists/CustomPickerList.cs
+++ b/FavCat/CustomLists/CustomPickerList.cs
@@ -147,7 +147,7 @@ namespace FavCat.CustomLists
             }
             catch (Exception ex)
             {
-                MelonLogger.Error(ex.ToString());
+                FavCatMod.Logger.Error(ex.ToString());
             }
         }
 

--- a/FavCat/Database/DatabaseImageHandler.cs
+++ b/FavCat/Database/DatabaseImageHandler.cs
@@ -72,12 +72,12 @@ namespace FavCat.Database
 
                 await TaskUtilities.YieldToMainThread();
                 
-                MelonLogger.Msg($"Removed {cutoffPoint} images from cache");
+                FavCatMod.Logger.Msg($"Removed {cutoffPoint} images from cache");
             }).ContinueWith(task =>
             {
                 if (!task.IsFaulted) return;
                 
-                MelonLogger.Warning("Image cache trim failed; assuming cache corrupted, clearing collections. Exception: " + task.Exception);
+                FavCatMod.Logger.Warning("Image cache trim failed; assuming cache corrupted, clearing collections. Exception: " + task.Exception);
                 myFileDatabase.GetCollection<LiteFileInfo<string>>("_files").DeleteAll();
                 myFileDatabase.GetCollection("_chunks").DeleteAll();
             });
@@ -109,13 +109,13 @@ namespace FavCat.Database
                 }
                 catch (Exception ex)
                 {
-                    MelonLogger.Error($"Exception in onDone callback: {ex}");
+                    FavCatMod.Logger.Error($"Exception in onDone callback: {ex}");
                 }
             }
             catch (Exception ex)
             {
                 if (MelonDebug.IsEnabled())
-                    MelonLogger.Warning($"Exception in image load, will delete offending image: {ex}");
+                    FavCatMod.Logger.Warning($"Exception in image load, will delete offending image: {ex}");
                 myFileDatabase.FileStorage.Delete(url);
                 myImageInfos.Delete(url);
                 onDone(AssetsHandler.PreviewLoading.texture);
@@ -158,7 +158,7 @@ namespace FavCat.Database
                 catch (LiteException ex)
                 {
                     if (MelonDebug.IsEnabled())
-                        MelonLogger.Warning($"Database exception in image store handler: {ex}");
+                        FavCatMod.Logger.Warning($"Database exception in image store handler: {ex}");
                 }
             });
         }

--- a/FavCat/Database/LocalStoreDatabase.Avatar.cs
+++ b/FavCat/Database/LocalStoreDatabase.Avatar.cs
@@ -13,7 +13,7 @@ namespace FavCat.Database
     {
         internal void RunBackgroundAvatarSearch(string text, Action<IEnumerable<StoredAvatar>> callback)
         {
-            MelonLogger.Msg($"Running local avatar search for text {text}");
+            FavCatMod.Logger.Msg($"Running local avatar search for text {text}");
             var ownerId = APIUser.CurrentUser.id;
             Task.Run(() => {
                 var searchText = text.ToLowerInvariant();
@@ -31,7 +31,7 @@ namespace FavCat.Database
         
         internal void RunBackgroundAvatarSearchByUser(string userId, Action<IEnumerable<StoredAvatar>> callback)
         {
-            MelonLogger.Msg($"Running local avatar search for user {userId}");
+            FavCatMod.Logger.Msg($"Running local avatar search for user {userId}");
             var ownerId = APIUser.CurrentUser.id;
             Task.Run(() => {
                 var list = myStoredAvatars.Find(stored =>

--- a/FavCat/Database/LocalStoreDatabase.Player.cs
+++ b/FavCat/Database/LocalStoreDatabase.Player.cs
@@ -31,7 +31,7 @@ namespace FavCat.Database
         
         internal void RunBackgroundPlayerSearch(string text, Action<IEnumerable<StoredPlayer>> callback)
         {
-            MelonLogger.Msg($"Running local player search for text {text}");
+            FavCatMod.Logger.Msg($"Running local player search for text {text}");
             Task.Run(() => {
                 var searchText = text.ToLowerInvariant();
                 var list = myStoredPlayers.Find(stored => stored.Name.Contains(searchText)).ToList();

--- a/FavCat/Database/LocalStoreDatabase.World.cs
+++ b/FavCat/Database/LocalStoreDatabase.World.cs
@@ -13,7 +13,7 @@ namespace FavCat.Database
     {
         internal void RunBackgroundWorldSearch(string text, Action<IEnumerable<StoredWorld>> callback)
         {
-            MelonLogger.Msg($"Running local world search for text {text}");
+            FavCatMod.Logger.Msg($"Running local world search for text {text}");
             Task.Run(() => {
                 var searchText = text.ToLowerInvariant();
                 var list = myStoredWorlds.Find(stored =>

--- a/FavCat/Database/LocalStoreDatabase.cs
+++ b/FavCat/Database/LocalStoreDatabase.cs
@@ -42,7 +42,7 @@ namespace FavCat.Database
             }
             catch (Exception ex)
             {
-                MelonLogger.Warning("Exception when creating image cache; assuming it's corrupted and deleting it. Exception: " + ex);
+                FavCatMod.Logger.Warning("Exception when creating image cache; assuming it's corrupted and deleting it. Exception: " + ex);
                 File.Delete(imageDbPath);
                 myImageDatabase = new LiteDatabase(new ConnectionString { Filename = imageDbPath, Connection = connectionType });
             }
@@ -79,7 +79,7 @@ namespace FavCat.Database
                     }
                     catch (Exception ex)
                     {
-                        MelonLogger.Error($"Exception in DB update thread: {ex}");
+                        FavCatMod.Logger.Error($"Exception in DB update thread: {ex}");
                     }
                 } else
                     Thread.Sleep(100);

--- a/FavCat/FavCatMod.cs
+++ b/FavCat/FavCatMod.cs
@@ -26,17 +26,20 @@ namespace FavCat
     internal partial class FavCatMod : MelonMod
     {
         public static LocalStoreDatabase? Database;
+        public static MelonLogger.Instance Logger;
+        
         internal static FavCatMod Instance;
 
         internal AvatarModule? AvatarModule;
         internal WorldsModule? WorldsModule;
         internal PlayersModule? PlayerModule;
-        
+
         internal static PageUserInfo PageUserInfo;
         
         public override void OnApplicationStart()
         {
             Instance = this;
+            Logger = LoggerInstance;
             if (!CheckWasSuccessful || !MustStayTrue || MustStayFalse) return;
 
             Directory.CreateDirectory("./UserData/FavCatImport");
@@ -48,7 +51,7 @@ namespace FavCat
             
             FavCatSettings.RegisterSettings();
             
-            MelonLogger.Msg("Creating database");
+            Logger.Msg("Creating database");
             Database = new LocalStoreDatabase(FavCatSettings.DatabasePath.Value, FavCatSettings.ImageCachePath.Value);
             
             Database.ImageHandler.TrimCache(FavCatSettings.MaxCacheSizeBytes).NoAwait();
@@ -96,7 +99,7 @@ namespace FavCat
             }
             catch (Exception ex)
             {
-                MelonLogger.Error($"Exception in avatar module init: {ex}");
+                Logger.Error($"Exception in avatar module init: {ex}");
             }
 
             try
@@ -106,7 +109,7 @@ namespace FavCat
             }
             catch (Exception ex)
             {
-                MelonLogger.Error($"Exception in world module init: {ex}");
+                Logger.Error($"Exception in world module init: {ex}");
             }
             
             try
@@ -116,11 +119,11 @@ namespace FavCat
             }
             catch (Exception ex)
             {
-                MelonLogger.Error($"Exception in player module init: {ex}");
+                Logger.Error($"Exception in player module init: {ex}");
             }
 
             PageUserInfo = GameObject.Find("UserInterface/MenuContent/Screens/UserInfo").GetComponent<PageUserInfo>();
-            MelonLogger.Msg("Initialized!");
+            Logger.Msg("Initialized!");
         }
 
         public override void OnUpdate()
@@ -202,7 +205,7 @@ namespace FavCat
             }
             catch (Exception ex)
             {
-                MelonLogger.Error($"Exception in image downloader patch: {ex}");
+                FavCatMod.Logger.Error($"Exception in image downloader patch: {ex}");
             }
         }
 
@@ -238,7 +241,7 @@ namespace FavCat
             }
             catch (Exception ex)
             {
-                MelonLogger.Error($"Exception in API sniffer patch: {ex}");
+                FavCatMod.Logger.Error($"Exception in API sniffer patch: {ex}");
             }
         }
     }

--- a/FavCat/GlobalImageCache.cs
+++ b/FavCat/GlobalImageCache.cs
@@ -82,7 +82,7 @@ namespace FavCat
             
             ourNextAllowedUpdate = Time.time + RequestDelay;
             
-            MelonLogger.Msg($"Performing image request to {url}");
+            FavCatMod.Logger.Msg($"Performing image request to {url}");
             ImageDownloader.DownloadImage(url, 256, new Action<Texture2D>(tex =>
             {
                 if (!Textures.TryGetValue(url, out var oldTex) || !oldTex)

--- a/FavCat/ImportFolderProcessor.cs
+++ b/FavCat/ImportFolderProcessor.cs
@@ -47,7 +47,7 @@ namespace FavCat
                 }
                 catch (Exception ex)
                 {
-                    MelonLogger.Msg($"Import of {file} failed: {ex}");
+                    FavCatMod.Logger.Msg($"Import of {file} failed: {ex}");
                 }
             }
             
@@ -62,7 +62,7 @@ namespace FavCat
                 }
                 catch (Exception ex)
                 {
-                    MelonLogger.Msg($"Import of {file} failed: {ex}");
+                    FavCatMod.Logger.Msg($"Import of {file} failed: {ex}");
                 }
             }
 
@@ -78,12 +78,12 @@ namespace FavCat
             var database = FavCatMod.Database;
             if (database == null)
             {
-                MelonLogger.Msg("Database does not exist, can't import");
+                FavCatMod.Logger.Msg("Database does not exist, can't import");
                 return;
             }
             
             var fileName = Path.GetFileName(filePath);
-            MelonLogger.Msg($"Started avatar import process for file {fileName}");
+            FavCatMod.Logger.Msg($"Started avatar import process for file {fileName}");
             
             var toAddUsers = new List<string>();
             var toAddWorlds = new List<string>();
@@ -158,7 +158,7 @@ namespace FavCat
             DoAddCategories(toAddWorlds, database.WorldFavorites, FavCatMod.Instance.WorldsModule, database.myStoredWorlds);
             DoAddCategories(toAddUsers, database.PlayerFavorites, FavCatMod.Instance.PlayerModule, database.myStoredPlayers);
             
-            MelonLogger.Msg($"Done importing {fileName}");
+            FavCatMod.Logger.Msg($"Done importing {fileName}");
             File.Delete(filePath);
         }
         
@@ -169,12 +169,12 @@ namespace FavCat
                 var database = FavCatMod.Database;
                 if (database == null)
                 {
-                    MelonLogger.Msg("Database does not exist, can't merge");
+                    FavCatMod.Logger.Msg("Database does not exist, can't merge");
                     return;
                 }
                 
                 var fileName = Path.GetFileName(foreignStorePath);
-                MelonLogger.Msg($"Started merging database with {fileName}");
+                FavCatMod.Logger.Msg($"Started merging database with {fileName}");
                 using var storeDatabase = new LiteDatabase(new ConnectionString {Filename = foreignStorePath, ReadOnly = true, Connection = ConnectionType.Direct});
             
                 var storedAvatars = storeDatabase.GetCollection<StoredAvatar>("avatars");
@@ -205,7 +205,7 @@ namespace FavCat
                         database.myStoredWorlds.Upsert(storedWorld);
                 }
                 
-                MelonLogger.Msg($"Done merging database with {fileName}");
+                FavCatMod.Logger.Msg($"Done merging database with {fileName}");
             });
         }
     }

--- a/FavCat/Modules/AvatarModule.cs
+++ b/FavCat/Modules/AvatarModule.cs
@@ -31,7 +31,7 @@ namespace FavCat.Modules
         {
             myCurrentAnnoyingMessage = CanPerformAdditiveActions ? "WillBeObsolete" : (CanShowExistingLists ? "CantAddWithCanny" : "NoFavorites");
             
-            MelonLogger.Msg("Adding button to UI - Looking up for Change Button");
+            FavCatMod.Logger.Msg("Adding button to UI - Looking up for Change Button");
             var foundAvatarPage = Resources.FindObjectsOfTypeAll<PageAvatar>()?.FirstOrDefault(p => p.transform.Find("Change Button") != null);
             if (foundAvatarPage == null)
                 throw new ApplicationException("No avatar page, can't initialize extended favorites");

--- a/FavCat/Modules/ExtendedFavoritesModuleBase.cs
+++ b/FavCat/Modules/ExtendedFavoritesModuleBase.cs
@@ -257,7 +257,7 @@ namespace FavCat.Modules
             foreach (var list in GatherLists(true))
             {
                 if (MelonDebug.IsEnabled() && knownLists.ContainsKey(list.ListName))
-                    MelonLogger.Msg($"List {list.ListName} is duplicated");
+                    FavCatMod.Logger.Msg($"List {list.ListName} is duplicated");
                 
                 knownLists[list.ListName] = list;
             }
@@ -582,7 +582,7 @@ namespace FavCat.Modules
             mySearchResult = null;
             if (results == null) return;
             
-            MelonLogger.Msg("Local search done, {0} results", results.Count);
+            FavCatMod.Logger.Msg("Local search done, {0} results", results.Count);
 
             SortModelList(SearchList.Category.SortType, SearchCategoryName, results);
             SearchList.SetList(results.Select(it => WrapModel(null, it.it)), true);

--- a/FriendsPlusHome/FriendsPlusHomeMod.cs
+++ b/FriendsPlusHome/FriendsPlusHomeMod.cs
@@ -25,9 +25,12 @@ namespace FriendsPlusHome
 
         private static MelonPreferences_Entry<string> StartupName;
         private static MelonPreferences_Entry<string> ButtonName;
+        private static MelonLogger.Instance Logger;
 
         public override void OnApplicationStart()
         {
+            Logger = LoggerInstance;
+            
             var category = MelonPreferences.CreateCategory(SettingsCategory, "Friends+ Home");
             StartupName = category.CreateEntry(SettingStartupName, nameof(InstanceAccessType.FriendsOfGuests), "Startup instance type");
             ButtonName = category.CreateEntry(SettingButtonName, nameof(InstanceAccessType.FriendsOfGuests), "\"Go Home\" instance type");
@@ -43,7 +46,7 @@ namespace FriendsPlusHome
                 if (!XrefScanner.XrefScan(methodInfo).Any(it => it.Type == XrefType.Global && it.ReadAsObject()?.ToString() == "Going to Home Location: ")) 
                     continue;
                 
-                MelonLogger.Msg($"Patched {methodInfo.Name}");
+                Logger.Msg($"Patched {methodInfo.Name}");
                 HarmonyInstance.Patch(methodInfo, postfix: new HarmonyMethod(AccessTools.Method(typeof(FriendsPlusHomeMod), nameof(GoHomePatch))));
             }
             
@@ -78,7 +81,7 @@ namespace FriendsPlusHome
         private static void StartEnforcingInstanceType(VRCFlowManager flowManager, bool isButton)
         {
             var targetType = Enum.TryParse<InstanceAccessType>(isButton ? ButtonName.Value : StartupName.Value, out var type) ? type : InstanceAccessType.FriendsOfGuests;
-            MelonLogger.Msg($"Enforcing home instance type: {targetType}");
+            Logger.Msg($"Enforcing home instance type: {targetType}");
             flowManager.field_Protected_InstanceAccessType_0 = targetType;
 
             MelonCoroutines.Start(EnforceTargetInstanceType(flowManager, targetType, isButton ? 10 : 30));

--- a/IKTweaks/IKTweaksMod.cs
+++ b/IKTweaks/IKTweaksMod.cs
@@ -18,9 +18,13 @@ namespace IKTweaks
 {
     internal partial class IKTweaksMod : MelonMod
     {
+        public static MelonLogger.Instance Logger;
+        
         public override void OnApplicationStart()
         {
             if (!CheckWasSuccessful || !MustStayTrue || MustStayFalse) return;
+
+            Logger = LoggerInstance;
             
             IkTweaksSettings.RegisterSettings();
 

--- a/IKTweaks/VrIkHandling.cs
+++ b/IKTweaks/VrIkHandling.cs
@@ -64,7 +64,7 @@ namespace IKTweaks
             }
             catch (Exception ex)
             {
-                MelonLogger.Error($"Exception in IK solver: {ex}");
+                IKTweaksMod.Logger.Error($"Exception in IK solver: {ex}");
             }
         }
 
@@ -122,7 +122,7 @@ namespace IKTweaks
             }
             catch (Exception ex)
             {
-                MelonLogger.Error($"Exception in IK spine solver: {ex}");
+                IKTweaksMod.Logger.Error($"Exception in IK spine solver: {ex}");
             }
         }
 

--- a/JoinNotifier/JoinNotifierMod.cs
+++ b/JoinNotifier/JoinNotifierMod.cs
@@ -49,7 +49,7 @@ namespace JoinNotifier
         public override void OnApplicationStart()
         {
             if (!CheckWasSuccessful || !MustStayTrue || MustStayFalse) return;
-            
+
             JoinNotifierSettings.RegisterSettings();
 
             MelonCoroutines.Start(InitThings());
@@ -89,7 +89,7 @@ namespace JoinNotifier
 
             if (File.Exists(CustomJoinSoundFileName))
             {
-                MelonLogger.Msg("Loading custom join sound");
+                LoggerInstance.Msg("Loading custom join sound");
                 var uwr = UnityWebRequest.Get($"file://{Path.Combine(Environment.CurrentDirectory, CustomJoinSoundFileName)}");
                 uwr.SendWebRequest();
 
@@ -105,7 +105,7 @@ namespace JoinNotifier
 
             if (File.Exists(CustomLeaveSoundFileName))
             {
-                MelonLogger.Msg("Loading custom leave sound");
+                LoggerInstance.Msg("Loading custom leave sound");
                 
                 var uwr = UnityWebRequest.Get($"file://{Path.Combine(Environment.CurrentDirectory, CustomLeaveSoundFileName)}");
                 uwr.SendWebRequest();
@@ -216,7 +216,7 @@ namespace JoinNotifier
             var hudRoot = GameObject.Find("UserInterface/UnscaledUI/HudContent_Old/Hud");
             if (hudRoot == null)
             {
-                MelonLogger.Msg("Not creating gameobjects - no hud root");
+                LoggerInstance.Msg("Not creating gameobjects - no hud root");
                 return;
             }
             
@@ -267,7 +267,7 @@ namespace JoinNotifier
             if (JoinNotifierSettings.ShouldShowNames(true))
                 MelonCoroutines.Start(ShowName(myJoinText, myJoinNames, playerName, true, isFriendsWith));
             if (JoinNotifierSettings.LogToConsole.Value)
-                MelonLogger.Msg(isFriendsWith && JoinNotifierSettings.ShowFriendsInDifferentColor.Value
+                LoggerInstance.Msg(isFriendsWith && JoinNotifierSettings.ShowFriendsInDifferentColor.Value
                         ? ConsoleColor.DarkYellow : ConsoleColor.DarkCyan, 
                     $"{(isFriendsWith ? "Friend " : "")}{playerName} joined");
         }
@@ -295,7 +295,7 @@ namespace JoinNotifier
             if (JoinNotifierSettings.ShouldShowNames(false))
                 MelonCoroutines.Start(ShowName(myLeaveText, myLeaveNames, playerName, false, isFriendsWith));
             if (JoinNotifierSettings.LogToConsole.Value)
-                MelonLogger.Msg(isFriendsWith && JoinNotifierSettings.ShowFriendsInDifferentColor.Value
+                LoggerInstance.Msg(isFriendsWith && JoinNotifierSettings.ShowFriendsInDifferentColor.Value
                         ? ConsoleColor.DarkYellow : ConsoleColor.DarkMagenta, 
                     $"{(isFriendsWith ? "Friend " : "")}{playerName} left");
         }

--- a/LagFreeScreenshots/AwaitProvider.cs
+++ b/LagFreeScreenshots/AwaitProvider.cs
@@ -31,7 +31,7 @@ namespace LagFreeScreenshots
                 }
                 catch (Exception ex)
                 {
-                    MelonLogger.Warning($"Exception in task: {ex}");
+                    LagFreeScreenshotsMod.Logger.Warning($"Exception in task: {ex}");
                 }
             }
         }

--- a/MirrorResolutionUnlimiter/MirrorResolutionUnlimiterMod.cs
+++ b/MirrorResolutionUnlimiter/MirrorResolutionUnlimiterMod.cs
@@ -27,6 +27,7 @@ namespace MirrorResolutionUnlimiter
         private static bool ourAllMirrorsAuto = false;
         private static int ourMirrorMsaa = 0;
         private static MelonPreferences_Entry<bool> ourMsaaIsUpperLimit;
+        private static MelonLogger.Instance ourLogger;
         internal static MelonPreferences_Entry<bool> UiInMirrors;
 
         private MelonPreferences_Entry<string> myPixelLightsSetting;
@@ -34,6 +35,8 @@ namespace MirrorResolutionUnlimiter
         public override void OnApplicationStart()
         {
             ClassInjector.RegisterTypeInIl2Cpp<OriginalPixelLightsSettingKeeper>();
+
+            ourLogger = LoggerInstance;
 
             var category = MelonPreferences.CreateCategory(ModCategory, "Mirror Resolution");
             var maxTextureRes = category.CreateEntry(MaxResPref, 4096, "Max eye texture size");
@@ -68,7 +71,7 @@ namespace MirrorResolutionUnlimiter
 
             if (MelonHandler.Mods.Any(it => it.Info.Name == "UI Expansion Kit"))
             {
-                MelonLogger.Msg("Adding UIExpansionKit buttons");
+                ourLogger.Msg("Adding UIExpansionKit buttons");
                 UiExtensionsAddon.Init();
             }
         }
@@ -169,7 +172,7 @@ namespace MirrorResolutionUnlimiter
             }
             catch (Exception ex)
             {
-                MelonLogger.Error("Exception happened in GetReflectionData override" + ex);
+                ourLogger.Error("Exception happened in GetReflectionData override" + ex);
             }
             return true;
         }

--- a/ScaleGoesBrr/ScaleGoesBrrMod.cs
+++ b/ScaleGoesBrr/ScaleGoesBrrMod.cs
@@ -22,6 +22,7 @@ namespace ScaleGoesBrr
 
         private static VRCVrCameraSteam ourSteamCamera;
         private static Transform ourCameraTransform;
+        private static MelonLogger.Instance ourLogger;
 
         public static event Action<Transform, float> OnAvatarScaleChanged;
 
@@ -33,6 +34,8 @@ namespace ScaleGoesBrr
         public override void OnApplicationStart()
         {
             ClassInjector.RegisterTypeInIl2Cpp<ScaleGoesBrrComponent>();
+
+            ourLogger = LoggerInstance;
 
             var category = MelonPreferences.CreateCategory("ScaleGoesBrr", "Scale Goes Brr");
             ourIsEnabled = category.CreateEntry("Enabled", true, "Enable avatar scaling support");
@@ -119,7 +122,7 @@ namespace ScaleGoesBrr
 
             var originalTrackingRootScale = trackingRoot.localScale;
 
-            MelonLogger.Msg($"Initialized scaling support for current avatar: avatar initial scale {originalScale.y}, tracking initial scale {originalTrackingRootScale.y}");
+            ourLogger.Msg($"Initialized scaling support for current avatar: avatar initial scale {originalScale.y}, tracking initial scale {originalTrackingRootScale.y}");
 
             var comp = go.AddComponent<ScaleGoesBrrComponent>();
             comp.source = go.transform;
@@ -173,7 +176,7 @@ namespace ScaleGoesBrr
             
             if (descriptor == null || descriptor.TryCast<VRCSDK2.VRC_AvatarDescriptor>() != null)
             {
-                MelonLogger.Msg("Current avatar is SDK2, ignoring rescaling support");
+                ourLogger.Msg("Current avatar is SDK2, ignoring rescaling support");
                 return;
             }
 

--- a/Styletor/ExtraHandlers/ActionMenuHandler.cs
+++ b/Styletor/ExtraHandlers/ActionMenuHandler.cs
@@ -139,7 +139,7 @@ namespace Styletor.ExtraHandlers
             var name = texture.name;
             
             if (myTexturesByName.TryGetValue(name, out var previous) && previous != texture)
-                MelonLogger.Msg($"Object named {name} as a texture different from previous one: {previous.name} != {texture.name}");
+                StyletorMod.Instance.Logger.Msg($"Object named {name} as a texture different from previous one: {previous.name} != {texture.name}");
 
             myTexturesByName[name] = texture;
         }
@@ -175,7 +175,7 @@ namespace Styletor.ExtraHandlers
             var name = texture.name;
             
             if (mySpritesByName.TryGetValue(name, out var previous) && previous != texture)
-                MelonLogger.Msg($"Object named {name} as a texture different from previous one: {previous.name} != {texture.name}");
+                StyletorMod.Instance.Logger.Msg($"Object named {name} as a texture different from previous one: {previous.name} != {texture.name}");
 
             mySpritesByName[name] = texture;
         }
@@ -189,11 +189,11 @@ namespace Styletor.ExtraHandlers
             if (graphics.Count > 0)
             {
                 if (graphics.Count > 1)
-                    MelonLogger.Msg($"AM object {fullName} (in {t.parent.gameObject.name}) has more than one Graphic!");
+                    StyletorMod.Instance.Logger.Msg($"AM object {fullName} (in {t.parent.gameObject.name}) has more than one Graphic!");
 
                 var color = graphics[0].color;
                 if (myOriginalGraphicColorsByObjectName.TryGetValue(fullName, out var oldColor) && oldColor != color)
-                    MelonLogger.Msg($"Object named {fullName} was seen with two different colors: {oldColor.ToString()} vs {color.ToString()}");
+                    StyletorMod.Instance.Logger.Msg($"Object named {fullName} was seen with two different colors: {oldColor.ToString()} vs {color.ToString()}");
 
                 myOriginalGraphicColorsByObjectName[fullName] = color;
                 

--- a/Styletor/StyleEngineWrapper.cs
+++ b/Styletor/StyleEngineWrapper.cs
@@ -161,7 +161,7 @@ namespace Styletor
                     myOriginalSpritesByLowercaseFullKey[keyValuePair.Key.Item1] = keyValuePair.Value.Cast<Sprite>();
             }
 
-            MelonLogger.Msg($"Stored default style: {myOriginalStylesBackup.Count} styles, {myOriginalSprites.Count} sprites");
+            StyletorMod.Instance.Logger.Msg($"Stored default style: {myOriginalStylesBackup.Count} styles, {myOriginalSprites.Count} sprites");
         }
 
         public string? GetSpriteFullNameByOriginalSprite(Sprite? originalSprite)

--- a/Styletor/Styles/BuiltinStyleExporter.cs
+++ b/Styletor/Styles/BuiltinStyleExporter.cs
@@ -19,7 +19,7 @@ namespace Styletor.Styles
             var spriteType = Il2CppType.Of<Sprite>();
             var audioClipType = Il2CppType.Of<AudioClip>();
             
-            MelonLogger.Msg($"Exporting default VRC skin to {baseDir}");
+            StyletorMod.Instance.Logger.Msg($"Exporting default VRC skin to {baseDir}");
             foreach (var keyValuePair in styleEngine.field_Private_Dictionary_2_Tuple_2_String_Type_Object_0)
             {
                 var basePath = Path.Combine(baseDir, keyValuePair.Key.Item1);
@@ -42,7 +42,7 @@ namespace Styletor.Styles
                     WriteWaveFile(basePath + ".wav", audioClip);
                 }
             }
-            MelonLogger.Msg($"Export finished");
+            StyletorMod.Instance.Logger.Msg($"Export finished");
         }
 
         private static void WriteWaveFile(string filePath, AudioClip clip)

--- a/Styletor/Styles/OverrideStyle.cs
+++ b/Styletor/Styles/OverrideStyle.cs
@@ -92,7 +92,7 @@ namespace Styletor.Styles
                 var loadedTexture = Utils.Utils.LoadTexture(keyValuePair.Value);
                 if (loadedTexture == null)
                 {
-                    MelonLogger.Msg($"Failed to load a texture from {keyValuePair.Key}");
+                    StyletorMod.Instance.Logger.Msg($"Failed to load a texture from {keyValuePair.Key}");
                     continue;
                 }
 

--- a/Styletor/Styles/OverridesStyleSheet.cs
+++ b/Styletor/Styles/OverridesStyleSheet.cs
@@ -127,7 +127,7 @@ namespace Styletor.Styles
                 var targetNormalizedSelector = keyValuePair.Value.SelectorTo.ToStringNormalized();
                 if (baseStyles == null || baseStyles.Count == 0)
                 {
-                    MelonLogger.Msg($"Selector {keyValuePair.Value.SelectorFrom} not found in default style to copy into {targetNormalizedSelector}");
+                    StyletorMod.Instance.Logger.Msg($"Selector {keyValuePair.Value.SelectorFrom} not found in default style to copy into {targetNormalizedSelector}");
                     continue;
                 }
 
@@ -165,7 +165,7 @@ namespace Styletor.Styles
                 var baseStyles = myStyleEngine.TryGetBySelector(keyValuePair.Key);
                 if (baseStyles == null && !keyValuePair.Value.IsNew)
                 {
-                    MelonLogger.Msg($"Selector {keyValuePair.Key} overrides nothing in default style and is not marked as new (see README)");
+                    StyletorMod.Instance.Logger.Msg($"Selector {keyValuePair.Key} overrides nothing in default style and is not marked as new (see README)");
                     continue;
                 }
                 
@@ -185,7 +185,7 @@ namespace Styletor.Styles
                 }
             }
             
-            MelonLogger.Msg($"Applied {myStyleOverrides.Count} overrides from {Name}");
+            StyletorMod.Instance.Logger.Msg($"Applied {myStyleOverrides.Count} overrides from {Name}");
         }
 
         private static Selector ParseSelector(string selectorText) => Selector.Method_Public_Static_Selector_String_0(selectorText.Trim());
@@ -199,13 +199,13 @@ namespace Styletor.Styles
                 var selectorNormalized = selector.ToStringNormalized();
 
                 if (myStyleOverrides.ContainsKey(selectorNormalized))
-                    MelonLogger.Warning($"Style sheet override {Name} contains duplicate selector {selectorNormalized}");
+                    StyletorMod.Instance.Logger.Warning($"Style sheet override {Name} contains duplicate selector {selectorNormalized}");
 
                 myStyleOverrides[selectorNormalized] = (isNew, bodyText);
             }
             catch (Exception ex)
             {
-                MelonLogger.Warning($"Error while parsing override style {Name}: {ex}");
+                StyletorMod.Instance.Logger.Warning($"Error while parsing override style {Name}: {ex}");
             }
         }
     }

--- a/Styletor/Styles/StylesLoader.cs
+++ b/Styletor/Styles/StylesLoader.cs
@@ -80,7 +80,7 @@ namespace Styletor.Styles
             }
             catch (Exception ex)
             {
-                MelonLogger.Warning($"Can't load style {styleRawName}: {ex}");
+                StyletorMod.Instance.Logger.Warning($"Can't load style {styleRawName}: {ex}");
             }
         }
 
@@ -140,11 +140,11 @@ namespace Styletor.Styles
 
             if (myStyles.TryGetValue(styleName, out var style))
             {
-                MelonLogger.Msg($"Applying style {styleName}");
+                StyletorMod.Instance.Logger.Msg($"Applying style {styleName}");
                 style.ApplyOverrides(myColorizer);
             }
             else
-                MelonLogger.Msg($"Style {styleName} not found");
+                StyletorMod.Instance.Logger.Msg($"Style {styleName} not found");
             
             foreach (var overrideStyle in mixinsToUse.Where(it => it.Metadata.MixinPriority >= 0))
                 overrideStyle.ApplyOverrides(myColorizer);
@@ -175,14 +175,14 @@ namespace Styletor.Styles
 
                 if (spriteThisWouldReplace == null || originalSpriteFullKey == null)
                 {
-                    MelonLogger.Msg($"Image {normalizedName} in StyletorStyles would replace nothing; it will be ignored");
+                    StyletorMod.Instance.Logger.Msg($"Image {normalizedName} in StyletorStyles would replace nothing; it will be ignored");
                     continue;
                 }
 
                 var texture = Utils.Utils.LoadTexture(imagePath);
                 if (texture == null)
                 {
-                    MelonLogger.Msg($"Could not load texture from image {normalizedName} in StyletorStyles");
+                    StyletorMod.Instance.Logger.Msg($"Could not load texture from image {normalizedName} in StyletorStyles");
                     continue;
                 }
 

--- a/Styletor/StyletorMod.cs
+++ b/Styletor/StyletorMod.cs
@@ -34,10 +34,12 @@ namespace Styletor
         private ActionMenuHandler myActionMenuHandler;
         
         public SettingsHolder Settings => mySettings;
+        public MelonLogger.Instance Logger;
 
         public override void OnApplicationStart()
         {
             Instance = this;
+            Logger = LoggerInstance;
 
             Directory.CreateDirectory(Path.Combine(MelonUtils.UserDataDirectory, StylesLoader.StylesSubDir));
             
@@ -136,7 +138,7 @@ namespace Styletor
             var initMethod = initMethods.Count == 1 ? initMethods[0] : null;
 
             if (initMethod == null) 
-                MelonLogger.Warning("No Init method on StyleEngine, will wait for natural init");
+                Logger.Warning("No Init method on StyleEngine, will wait for natural init");
             else
                 initMethod.Invoke(myStyleEngine.StyleEngine, Array.Empty<object>());*/
 
@@ -153,7 +155,7 @@ namespace Styletor
             }
             catch (Exception ex)
             {
-                MelonLogger.Error($"UI Laser recoloring handler failed to initialize: {ex}");
+                Logger.Error($"UI Laser recoloring handler failed to initialize: {ex}");
             }
             
             try
@@ -162,7 +164,7 @@ namespace Styletor
             }
             catch (Exception ex)
             {
-                MelonLogger.Error($"Action Menu recoloring handler failed to initialize: {ex}");
+                Logger.Error($"Action Menu recoloring handler failed to initialize: {ex}");
             }
         }
 

--- a/TrueShaderAntiCrash/TrueShaderAntiCrashMod.cs
+++ b/TrueShaderAntiCrash/TrueShaderAntiCrashMod.cs
@@ -43,8 +43,8 @@ namespace TrueShaderAntiCrash
 
             if (!ourOffsets.TryGetValue(unityPlayerHash, out var offset))
             {
-                MelonLogger.Error($"Unknown UnityPlayer hash: {unityPlayerHash}");
-                MelonLogger.Error("The mod will not work");
+                LoggerInstance.Error($"Unknown UnityPlayer hash: {unityPlayerHash}");
+                LoggerInstance.Error("The mod will not work");
                 return;
             }
             
@@ -63,7 +63,7 @@ namespace TrueShaderAntiCrash
             }
             catch (IOException ex)
             {
-                MelonLogger.Warning("Failed to write native unity plugin; will attempt loading it anyway. This is normal if you're running multiple instances of VRChat");
+                LoggerInstance.Warning("Failed to write native unity plugin; will attempt loading it anyway. This is normal if you're running multiple instances of VRChat");
                 MelonDebug.Msg(ex.ToString());
             }
 
@@ -81,7 +81,7 @@ namespace TrueShaderAntiCrash
 
                 if (loaded == IntPtr.Zero)
                 {
-                    MelonLogger.Error("Module load failed");
+                    LoggerInstance.Error("Module load failed");
                     return;
                 }
 

--- a/Turbones/JigglySolverApi.cs
+++ b/Turbones/JigglySolverApi.cs
@@ -104,7 +104,7 @@ namespace Turbones
             var lib = LoadLibraryA(dllName);
             if (lib == IntPtr.Zero)
             {
-                MelonLogger.Error("Native library load failed, mod won't work");
+                TurbonesMod.Logger.Error("Native library load failed, mod won't work");
                 return false;
             }
 
@@ -145,7 +145,7 @@ namespace Turbones
         private static T GetPointer<T>(IntPtr lib, string name) where T : MulticastDelegate
         {
             var result = Marshal.GetDelegateForFunctionPointer<T>(GetProcAddress(lib, name));
-            if (result == null) MelonLogger.Error($"Delegate for {name} not found! Bug?");
+            if (result == null) TurbonesMod.Logger.Error($"Delegate for {name} not found! Bug?");
 
             return result;
         }

--- a/Turbones/Offsets.cs
+++ b/Turbones/Offsets.cs
@@ -12,7 +12,7 @@ namespace Turbones
         public static IntPtr GetICall(string name)
         {
             var result = IL2CPP.il2cpp_resolve_icall(name);
-            if (result == IntPtr.Zero) MelonLogger.Error($"ICall {name} not found, crash will likely follow");
+            if (result == IntPtr.Zero) TurbonesMod.Logger.Error($"ICall {name} not found, crash will likely follow");
             
             MelonDebug.Msg($"ICall pointer for {name} is {result}");
             return result;
@@ -23,7 +23,7 @@ namespace Turbones
             var classPtr = Il2CppClassPointerStore<T>.NativeClassPtr;
             if (classPtr == IntPtr.Zero)
             {
-                MelonLogger.Error($"{typeof(T)} class pointer is null");
+                TurbonesMod.Logger.Error($"{typeof(T)} class pointer is null");
                 return 0;
             }
 
@@ -33,21 +33,21 @@ namespace Turbones
                 var managedField = typeof(T).GetField("NativeFieldInfoPtr_" + fieldName, BindingFlags.Static | BindingFlags.NonPublic);
                 if (managedField == null)
                 {
-                    MelonLogger.Error($"Field {fieldName} is not found on type {typeof(T)} (managed)");
+                    TurbonesMod.Logger.Error($"Field {fieldName} is not found on type {typeof(T)} (managed)");
                     return 0;
                 }
                 fieldPtr = (IntPtr) managedField.GetValue(null);
 
                 if (fieldPtr == IntPtr.Zero)
                 {
-                    MelonLogger.Error($"Field {fieldName} is not found on type {typeof(T)} (ptr)");
+                    TurbonesMod.Logger.Error($"Field {fieldName} is not found on type {typeof(T)} (ptr)");
                     return 0;
                 }
             }
 
             var fieldOffset = IL2CPP.il2cpp_field_get_offset(fieldPtr);
             if (fieldOffset <= 0) 
-                MelonLogger.Error($"Field offset for field {typeof(T)}.{fieldName} is {fieldOffset}");
+                TurbonesMod.Logger.Error($"Field offset for field {typeof(T)}.{fieldName} is {fieldOffset}");
             
             MelonDebug.Msg($"Field offset for field {typeof(T)}.{fieldName} is {fieldOffset}");
 
@@ -59,7 +59,7 @@ namespace Turbones
             if (module == IntPtr.Zero) return IntPtr.Zero;
             var result = JigglySolverApi.GetProcAddress(module, name);
             if (result == IntPtr.Zero)
-                MelonLogger.Error($"No entry point for {name}");
+                TurbonesMod.Logger.Error($"No entry point for {name}");
             else
                 MelonDebug.Msg($"Entry point for {name} is {result}");
 
@@ -72,7 +72,7 @@ namespace Turbones
 
             if (ga == IntPtr.Zero)
             {
-                MelonLogger.Error("GameAssembly was not found, crash will likely follow");
+                TurbonesMod.Logger.Error("GameAssembly was not found, crash will likely follow");
             }
 
             var icalls = new ICallOffsets

--- a/Turbones/TurbonesMod.cs
+++ b/Turbones/TurbonesMod.cs
@@ -17,6 +17,8 @@ namespace Turbones
 {
     internal partial class TurbonesMod : MelonMod
     {
+        public static MelonLogger.Instance Logger;
+        
         private static IntPtr ourDynBoneCollideEntryPoint;
         private static IntPtr ourDynBoneUpdateEntryPoint;
         private static IntPtr ourLastPatchPointer;
@@ -24,6 +26,8 @@ namespace Turbones
         public override void OnApplicationStart()
         {
             ClassInjector.RegisterTypeInIl2Cpp<BoneDeleteHandler>();
+
+            Logger = LoggerInstance;
             
             var category = MelonPreferences.CreateCategory("Turbones");
             var enableCollisionChecks = category.CreateEntry("OptimizedCollisionChecks", true, "Enable optimized collision checks");
@@ -43,13 +47,13 @@ namespace Turbones
             }
             catch (IOException ex)
             {
-                MelonLogger.Warning("Failed to write native dll; will attempt loading it anyway. This is normal if you're running multiple instances of VRChat");
+                Logger.Warning("Failed to write native dll; will attempt loading it anyway. This is normal if you're running multiple instances of VRChat");
                 MelonDebug.Msg(ex.ToString());
             }
 
             if (!JigglySolverApi.Initialize("VRChat_Data/Plugins/" + dllName))
             {
-                MelonLogger.Error("Error initializing native library; mod won't work");
+                Logger.Error("Error initializing native library; mod won't work");
                 return;
             }
 
@@ -71,7 +75,7 @@ namespace Turbones
                 fixed(IntPtr* a = &ourDynBoneCollideEntryPoint)
                     MelonUtils.NativeHookAttach((IntPtr)a, JigglySolverApi.LibDynBoneCollideEntryPoint);
 
-                MelonLogger.Msg("Patched DynamicBone Collide");
+                Logger.Msg("Patched DynamicBone Collide");
                 isCollidePatched = true;
             }
 
@@ -82,7 +86,7 @@ namespace Turbones
                 fixed(IntPtr* a = &ourDynBoneCollideEntryPoint)
                     MelonUtils.NativeHookDetach((IntPtr)a, JigglySolverApi.LibDynBoneCollideEntryPoint);
                 
-                MelonLogger.Msg("Unpatched DynamicBone Collide");
+                Logger.Msg("Unpatched DynamicBone Collide");
                 isCollidePatched = false;
             }
 
@@ -96,7 +100,7 @@ namespace Turbones
                     fixed(IntPtr* a = &ourDynBoneUpdateEntryPoint)
                         MelonUtils.NativeHookDetach((IntPtr)a, ourLastPatchPointer);
                     
-                    MelonLogger.Msg("Unpatched DynamicBone Update");
+                    Logger.Msg("Unpatched DynamicBone Update");
                     ourLastPatchPointer = IntPtr.Zero;
                 }
                 
@@ -109,7 +113,7 @@ namespace Turbones
                     fixed(IntPtr* a = &ourDynBoneUpdateEntryPoint)
                         MelonUtils.NativeHookAttach((IntPtr)a, ourLastPatchPointer);
 
-                    MelonLogger.Msg($"Patched DynamicBone Update (multithreaded: {useMt})");
+                    Logger.Msg($"Patched DynamicBone Update (multithreaded: {useMt})");
                 }
                 else
                 {
@@ -120,7 +124,7 @@ namespace Turbones
 
                     JigglySolverApi.SetOriginalBoneUpdateDelegate(ourDynBoneUpdateEntryPoint);
 
-                    MelonLogger.Msg($"Patched DynamicBone Update (notify)");
+                    Logger.Msg($"Patched DynamicBone Update (notify)");
                 }
             }
             

--- a/UIExpansionKit/API/Classes/AwaitProvider.cs
+++ b/UIExpansionKit/API/Classes/AwaitProvider.cs
@@ -50,7 +50,7 @@ namespace UIExpansionKit.API.Classes
                 }
                 catch (Exception ex)
                 {
-                    MelonLogger.Warning($"Exception in delegate queue {QueueName}: {ex}");
+                    UiExpansionKitMod.Instance.Logger.Warning($"Exception in delegate queue {QueueName}: {ex}");
                 }
             }
         }

--- a/UIExpansionKit/API/ExpansionKitApi.cs
+++ b/UIExpansionKit/API/ExpansionKitApi.cs
@@ -85,7 +85,7 @@ namespace UIExpansionKit.API
         {
             if (CustomCategoryUIs.ContainsKey(categoryName))
             {
-                MelonLogger.Error($"Custom UI for category {categoryName} is already registered");
+                UiExpansionKitMod.Instance.Logger.Error($"Custom UI for category {categoryName} is already registered");
                 return;
             }
 

--- a/UIExpansionKit/API/TaskUtilities.cs
+++ b/UIExpansionKit/API/TaskUtilities.cs
@@ -40,7 +40,7 @@ namespace UIExpansionKit.API
             task.ContinueWith(tsk =>
             {
                 if (tsk.IsFaulted)
-                    MelonLogger.Error($"Free-floating {taskInfo} failed with exception: {tsk.Exception}");
+                    UiExpansionKitMod.Instance.Logger.Error($"Free-floating {taskInfo} failed with exception: {tsk.Exception}");
             });
         }
     }

--- a/UIExpansionKit/ButtonFactory.cs
+++ b/UIExpansionKit/ButtonFactory.cs
@@ -18,7 +18,7 @@ namespace UIExpansionKit
             }
             catch (Exception ex)
             {
-                MelonLogger.Error($"Exception when creating a button for registration of {registration}: {ex}");
+                UiExpansionKitMod.Instance.Logger.Error($"Exception when creating a button for registration of {registration}: {ex}");
             }
         }
         

--- a/UIExpansionKit/FieldInject/InjectedField.cs
+++ b/UIExpansionKit/FieldInject/InjectedField.cs
@@ -31,7 +31,7 @@ namespace UIExpansionKit.FieldInject
                 var ownerClass = (Il2CppClass_24_2*) classPointer;
 
                 myOffset = (int)ownerClass->instance_size - IntPtr.Size;
-                MelonLogger.Msg($"Injecting field: current size {ownerClass->instance_size} added size {addedSize} offset {myOffset}");
+                UiExpansionKitMod.Instance.Logger.Msg($"Injecting field: current size {ownerClass->instance_size} added size {addedSize} offset {myOffset}");
 
                 var fieldType = (Il2CppType_16_0*)Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppType_16_0>());
                 *fieldType = ((Il2CppClass_24_2*)fieldTypePointer)->byval_arg;

--- a/UIExpansionKit/ModSettingsHandler.cs
+++ b/UIExpansionKit/ModSettingsHandler.cs
@@ -348,7 +348,7 @@ namespace UIExpansionKit
                                 break;
                             }
                             if (MelonDebug.IsEnabled())
-                                MelonLogger.Msg($"Unknown mod pref type {pref.GetType()}");
+                                UiExpansionKitMod.Instance.Logger.Msg($"Unknown mod pref type {pref.GetType()}");
                             break;
                     }
                 }

--- a/UIExpansionKit/StylingHelper.cs
+++ b/UIExpansionKit/StylingHelper.cs
@@ -84,13 +84,13 @@ namespace UIExpansionKit
             var requestedStyle = SewElementTypeIdField.Get(wrapper);
             if (string.IsNullOrEmpty(requestedStyle))
             {
-                MelonLogger.Error("Empty requested style on SEW");
+                UiExpansionKitMod.Instance.Logger.Error("Empty requested style on SEW");
                 return;
             }
 
             if (!ourDefaultStyleMap.TryGetValue(requestedStyle, out var className))
             {
-                MelonLogger.Error($"Unknown requested style: {requestedStyle}");
+                UiExpansionKitMod.Instance.Logger.Error($"Unknown requested style: {requestedStyle}");
                 return;
             }
 

--- a/UIExpansionKit/UiExpansionKitMod.cs
+++ b/UIExpansionKit/UiExpansionKitMod.cs
@@ -40,6 +40,8 @@ namespace UIExpansionKit
         internal Transform myCameraExpandoRoot;
         internal Transform myQmExpandosRoot;
         
+        public MelonLogger.Instance Logger;
+        
         private static readonly List<(ExpandedMenu, string, bool isFullMenu)> GameObjectToCategoryList = new List<(ExpandedMenu, string, bool)>
         {
             (ExpandedMenu.AvatarMenu, "UserInterface/MenuContent/Screens/Avatar", true),
@@ -77,6 +79,7 @@ namespace UIExpansionKit
         public override void OnApplicationStart()
         {
             Instance = this;
+            Logger = LoggerInstance;
             ClassInjector.RegisterTypeInIl2Cpp<EnableDisableListener>();
             ClassInjector.RegisterTypeInIl2Cpp<DestroyListener>();
             ClassInjector.RegisterTypeInIl2Cpp<StyleElementWrapper>();
@@ -165,7 +168,7 @@ namespace UIExpansionKit
                 }
                 catch (Exception ex)
                 {
-                    MelonLogger.Error($"Error while invoking UI-manager-init delegate {action.GetType().FullName}: {ex}");
+                    Logger.Error($"Error while invoking UI-manager-init delegate {action.GetType().FullName}: {ex}");
                 }
             }
 
@@ -182,7 +185,7 @@ namespace UIExpansionKit
                     }
                     catch (Exception ex)
                     {
-                        MelonLogger.Error($"Error while waiting for init of coroutine with type {coroutine.GetType().FullName}: {ex}");
+                        Logger.Error($"Error while waiting for init of coroutine with type {coroutine.GetType().FullName}: {ex}");
                         break;
                     }
                     yield return coroutine.Current;
@@ -217,7 +220,7 @@ namespace UIExpansionKit
 
         private void DecorateMenuPages()
         {
-            MelonLogger.Msg("Decorating menus");
+            Logger.Msg("Decorating menus");
             
             var quickMenuExpandoPrefab = myStuffBundle.QuickMenuExpando;
             var quickMenuRoot = GetQuickMenu().transform.Find("Container").gameObject;
@@ -244,7 +247,7 @@ namespace UIExpansionKit
                 var gameObject = UnityUtils.FindInactiveObjectInActiveRoot(gameObjectPath);
                 if (gameObject == null)
                 {
-                    MelonLogger.Error($"GameObject at path {gameObjectPath} for category {categoryEnum} was not found, not decorating");
+                    Logger.Error($"GameObject at path {gameObjectPath} for category {categoryEnum} was not found, not decorating");
                     continue;
                 }
                 
@@ -352,7 +355,7 @@ namespace UIExpansionKit
             var cameraController = UserCameraController.field_Internal_Static_UserCameraController_0;
             if (cameraController == null)
             {
-                MelonLogger.Warning("Camera controller not found, not decorating the camera");
+                Logger.Warning("Camera controller not found, not decorating the camera");
                 return;
             }
             

--- a/ViewPointTweaker/ViewPointTweakerMod.cs
+++ b/ViewPointTweaker/ViewPointTweakerMod.cs
@@ -63,7 +63,7 @@ namespace ViewPointTweaker
                 return;
             }
             
-            MelonLogger.Error("Steam tracking not found, things will break");
+            LoggerInstance.Error("Steam tracking not found, things will break");
         }
 
         private void SaveViewpoints()
@@ -78,7 +78,7 @@ namespace ViewPointTweaker
             var json = File.ReadAllText(ViewPointsFilePath);
             JSON.MakeInto(JSON.Load(json), out ourSavedViewpoints);
             
-            MelonLogger.Msg($"Loaded {ourSavedViewpoints.Count} saved viewpoints");
+            LoggerInstance.Msg($"Loaded {ourSavedViewpoints.Count} saved viewpoints");
         }
 
         private static void HeadAlignmentInitPatch(IKHeadAlignment __instance)


### PR DESCRIPTION
Converted MelonLogger usage to MelonLogger.Instance in all places it could be used, as using MelonLogger causes potential issues when the GetMelonFromStackTrace function is called.

This issue has been corrected with TotallyWholesome and emmVRC by emmVRC converting their usage of MelonLogger, it appears that any mods that are using the non Instance loggers can potential cause issues if the stack trace gets complex enough. The actual issue lies within Mono itself, and attempts to work around it haven't been successful, converting to Instance appears to be the simplest way to get everything working.

The issues usually manifest as either the game hanging, or the game fully crashing and resulting in a dump, both results show different parts of the Mono stack trace unwinder failing.

I tried to match formatting where applicable.

I've also added the reference to 0Harmony.dll to the Directory.Build.Props as it was missing.